### PR TITLE
fix: issue with the keyup event on the TextInput

### DIFF
--- a/src/components/common/PasswordInput.vue
+++ b/src/components/common/PasswordInput.vue
@@ -18,7 +18,7 @@ const isRevealed = ref(false);
 const toggleReveal = () => (isRevealed.value = !isRevealed.value);
 
 const props = defineProps<Properties>();
-const emit = defineEmits(['update:modelValue']);
+const emit = defineEmits(['update:modelValue', 'keyup']);
 const value = useVModel(props, 'modelValue', emit);
 </script>
 
@@ -32,6 +32,7 @@ const value = useVModel(props, 'modelValue', emit);
         :type="isRevealed ? 'text' : 'password'"
         :prepend-icon="IconFingerprint"
         :error="error"
+        @keyup="emit('keyup', $event)"
     >
         <template #append>
             <button

--- a/src/components/common/TextInput.vue
+++ b/src/components/common/TextInput.vue
@@ -25,7 +25,7 @@ const props = withDefaults(defineProps<Properties>(), {
     type: 'text'
 });
 
-const emit = defineEmits(['update:modelValue']);
+const emit = defineEmits(['update:modelValue', 'keyup']);
 const value = useVModel(props, 'modelValue', emit);
 
 function focusInput() {
@@ -78,6 +78,7 @@ function focusInput() {
                 :disabled="disabled"
                 class="peer placeholder:text-gray-400 w-full outline-none"
                 :class="[error ? 'text-red-600' : 'text-gray-700']"
+                @keyup="emit('keyup', $event)"
             />
             <slot name="append" />
         </div>


### PR DESCRIPTION
L'event `keyup` était trigger même lorsque le focus n'était pas dans l'input. Dans le cas du `PasswordInput` ça faisait qu'on pouvait plus changer le statut du `reveal` depuis le clavier sans trigger le `keyup.enter`.  

Comment observer l'ancien bug :
page login => remplir le champ `username` > remplir le champ `password` > sans quitter le champ mot de passe, tabuler une fois pour placer le focus sur le bouton reveal > appuyer sur enter  
> Là le login se déclenche alors qu'il ne devrait pas 